### PR TITLE
Prevent lost console output

### DIFF
--- a/nailgun-server/src/main/java/com/facebook/nailgun/Alias.java
+++ b/nailgun-server/src/main/java/com/facebook/nailgun/Alias.java
@@ -25,6 +25,7 @@ package com.facebook.nailgun;
  *
  * @author <a href="http://www.martiansoftware.com/contact.html">Marty Lamb</a>
  */
+@java.lang.SuppressWarnings("ComparableType")
 public class Alias implements Comparable {
 
   /** The alias name */

--- a/nailgun-server/src/main/java/com/facebook/nailgun/NGServer.java
+++ b/nailgun-server/src/main/java/com/facebook/nailgun/NGServer.java
@@ -559,8 +559,6 @@ public class NGServer implements Runnable {
   }
 
   private static boolean isSecurityManagerSupported() {
-    // Security manager was deprecated for removal in Java 17.
-    // Airbnb Fork: Always return true, as the security manager is deprecated but still exists in the runtimes we support.
-    return true; // return JavaVersionUtil.featureVersion() <= 16;
+    return JavaVersionUtil.featureVersion() <= 16;
   }
 }

--- a/nailgun-server/src/main/java/com/facebook/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/facebook/nailgun/NGSession.java
@@ -37,6 +37,9 @@ import java.util.logging.Logger;
  */
 public class NGSession extends Thread {
 
+  private static PrintStream CurrentConnectedPrintStreamOut;
+  private static PrintStream CurrentConnectedPrintStreamErr;
+
   @FunctionalInterface
   public interface CommnunicatorCreator {
     NGCommunicator get(Socket socket) throws IOException;
@@ -203,9 +206,11 @@ public class NGSession extends Thread {
       LOG.log(Level.FINEST, "NGSession {0} started cleanup", instanceNumber);
 
       if (System.in instanceof ThreadLocalInputStream) {
-        ((ThreadLocalInputStream) System.in).init(null);
-        ((ThreadLocalPrintStream) System.out).init(null);
-        ((ThreadLocalPrintStream) System.err).init(null);
+        ((ThreadLocalInputStream) System.in).init(NGServer.in);
+        NGServer.CurrentOut.set(NGServer.out);
+        NGServer.CurrentErr.set(NGServer.err);
+        ((ThreadLocalPrintStream) System.out).init(NGServer.out);
+        ((ThreadLocalPrintStream) System.err).init(NGServer.err);
       }
 
       LOG.log(Level.FINE, "NGSession {0} is closing client socket", instanceNumber);
@@ -228,6 +233,10 @@ public class NGSession extends Thread {
         PrintStream out = new PrintStream(new NGOutputStream(comm, NGConstants.CHUNKTYPE_STDOUT));
         PrintStream err =
             new PrintStream(new NGOutputStream(comm, NGConstants.CHUNKTYPE_STDERR)); ) {
+
+      NGServer.CurrentOut.set(out);
+      NGServer.CurrentErr.set(err);
+
       // ThreadLocal streams for System.in/out/err redirection
       if (System.in instanceof ThreadLocalInputStream) {
         ((ThreadLocalInputStream) System.in).init(in);

--- a/nailgun-server/src/main/java/com/facebook/nailgun/ThreadLocalInputStream.java
+++ b/nailgun-server/src/main/java/com/facebook/nailgun/ThreadLocalInputStream.java
@@ -29,7 +29,7 @@ import java.io.InputStream;
  *
  * @author <a href="http://www.martiansoftware.com/contact.html">Marty Lamb</a>
  */
-class ThreadLocalInputStream extends InputStream {
+public class ThreadLocalInputStream extends InputStream {
 
   /** The InputStreams for the various threads */
   private InheritableThreadLocal streams = null;
@@ -40,7 +40,7 @@ class ThreadLocalInputStream extends InputStream {
    * @param defaultInputStream the InputStream that will be used if the current thread has not
    *     called init()
    */
-  ThreadLocalInputStream(InputStream defaultInputStream) {
+  public ThreadLocalInputStream(InputStream defaultInputStream) {
     super();
     streams = new InheritableThreadLocal();
     this.defaultInputStream = defaultInputStream;


### PR DESCRIPTION
Problem
======
Nailgun server drops stdout/stderr when a long-lived thread is spawned from an incoming Nailgun client that then disconnects. This is a known issue that regularly causes issues for users e.g.
* https://youtrack.jetbrains.com/issue/SCL-18639/Scala-worksheet-fails-after-successful-run-of-same-code-due-to-RejectedExecutionException#focus=Comments-27-4880919.0-0
* https://youtrack.jetbrains.com/issue/SCL-19367/compile-server-terminated-unexpectedly-detection-is-unrealiable#focus=Comments-27-5074050.0-0

Solution
======
Update Nailgun server so that threads referencing disconnected streams will still send output to the "best" available console (which currently is defined by the last client that has connected). Note that when a valid ThreadLocal stream is not found, a better solution may be to fallback to sending output to all existing clients when multiple clients are connected, instead of just the last connected client (but this hasn't been implemented yet as we don't currently have a "multiple clients connected at the same time" use case at Airbnb)

Details
------
Airbnb has internally patched Jetbrain's latest version of the Nailgun server so that it prevents the losing of console output in the following scenario:
1. Nailgun Server starts and gets its own PrintStream
2. Nailgun Client 1 connects and runs a JUnit test which starts a Dropwizard server. Long-lived threads are spawned from the Dropwizard server and these threads get an InheritableThreadLocal that writes to Client 1's stdout. The JUnit test then makes a request to the started Dropwizard server and all output emitted from the Dropwizard server goes to Client 1's stdout.
3. Client 1 disconnects
4. Nailgun Client 2 connects and runs the same JUnit test as Client 1. The Dropwizard server is already started in the Nailgun server's JVM, so it is not started again (note that this is the main reason we're using Nailgun so that we can start a service once in a JVM using JBR and HotSwapAgent, and then reuse the service across re-running of tests). The JUnit test case then makes a request to the started Dropwizard server and all output emitted from the Dropwizard server is dropped by the code on master because the InheritableThreadLocal of the long-lived Dropwizard threads are now referring to Client 1's printstreams which are now closed. 
a) Note that the current code on master [tries to detect this case and fall-back to the original printstream](https://github.com/JetBrains/nailgun/blob/4421197b6b0fe2ff3a083b4ddbdb3f8dbed52222/nailgun-server/src/main/java/com/facebook/nailgun/ThreadLocalPrintStream.java#L68), but the PrintStream result is non-null, and closed.
b) This PR instead sends the output to `clientConnectedPrintStreamRef`, which was set when Client 2 connected.
5. Client 2 disconnects
6. A log is emitted by the Dropwizard server (this happened based on a scheduled task)
    a) This log would have been dropped by Nailgun on master, as the InheritableThreadLocal is referring to Client 1's stdout which is the client that was connected when the Dropwizard server started.
    b) This PR instead sends the output to originalPrintStream, which is the original PrintStream used by the Nailgun server.